### PR TITLE
Explicit Virtual Machine Name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,9 @@ Vagrant.configure("2") do |config|
   
           # VirtualBox
           instance.vm.provider 'virtualbox' do |vb|
+          # solve https://github.com/hashicorp/vagrant/issues/9524
+           vb.name = configuration[:hostname] + "-vm"
+
           # Boot in headless mode
             vb.gui = false
   


### PR DESCRIPTION
Hi,

I get into [VBox error VERR_CFGM_NOT_ENOUGH_SPACE](https://github.com/hashicorp/vagrant/issues/9524) and solved by explicitly setting the VM name.

I'm not an expert on Vagrant + VirtualBox so I do not know if it's the best solution. I send you this PR to open a discussion and avoid the same problem to other participants in the workshop.

Thank you. :smiley: